### PR TITLE
Hardware definition updates

### DIFF
--- a/config/hardware_definition.py
+++ b/config/hardware_definition.py
@@ -3,7 +3,7 @@ from devices import *
 board = Breakout_dseries_1_6()
 
 # Instantiate Devices.
-bci_link = UARTlink('bci_update', timer_freq=100)
+bci_link = UARTlink('cursor_update', timer_freq=100)
 
 motionSensor = MotionDetector(name='MotSen1', event='motion',
                               reset=board.port_1.DIO_C,
@@ -14,10 +14,11 @@ motionSensor = MotionDetector(name='MotSen1', event='motion',
 light = LEDStim()
 light.all_off()
 
-lickometer = Lickometer(lick_port=board.port_6, sol_port=board.port_7, rising_event_A='lick', debounce=5)
+lickometer = Lickometer(lick_port=board.port_6, sol_port=board.port_4, rising_event_A='lick', debounce=5)
 reward = Reward(lickometer.SOL_1 , reward_duration=50)
 
-sound = AudioStim(board.port_11)
+sound = AudioStim(board.port_11) # Audio player for sound stimul
+speaker = Speaker(board.port_7) # Speaker (Audio board) for frequency feedback
 
 cameraTrigger = CameraPulse(pin=board.port_1.POW_B, trigger_rate=100, duty_cycle=50)
 

--- a/devices/Speaker.py
+++ b/devices/Speaker.py
@@ -1,0 +1,15 @@
+"""
+Custom class for the Speaker device for frequency feedback. 
+"""
+
+import pyControl.hardware as _h
+from devices._audio_board import Audio_board
+
+
+class Speaker(Audio_board):
+    def __init__(self, port: _h.Port):
+        """
+        Initialize the Speaker device with the specified port.
+        """
+        super().__init__(port)
+        self.off() # Ensure the speaker is off initially

--- a/devices/_audio_board.py
+++ b/devices/_audio_board.py
@@ -1,0 +1,14 @@
+import pyb
+import pyControl.audio as _a
+
+class Audio_board(_a.Audio_output):
+
+    def __init__(self,  port):
+        assert port.DAC is not None, '! Audio board needs port with DAC.'
+        assert port.I2C is not None, '! Audio board needs port with I2C.'
+        self.I2C = pyb.I2C(port.I2C)
+        self.I2C.init(pyb.I2C.MASTER)
+        super().__init__(port.DAC)
+
+    def set_volume(self, V): # Set volume of audio output, range 0 - 127      
+        self.I2C.mem_write(int(V), 46, 0)


### PR DESCRIPTION
Updated the hardware_definition.py so that all branches share the same hardware definition file. 

Previously, AudiStim was commented out in the hardware definition file of GenJimmie branch, and Audio_board class was directly used.

```
#sound = AudioStim(board.port_11)
speaker = Audio_board(board.port_7)
```

Maintaining separate hardware definitions across branches created inconsistencies and may have contributed to noise issues during experiments.

To fix the problem, I created a Speaker class that inherits from Audio_board but initializes with the speaker disabled by default. This prevents interference in tasks that don't require the speaker while maintaining compatibility across all branches.

```
sound = AudioStim(board.port_11)  # Audio player for sound stimuli 
speaker = Speaker(board.port_7)   # Speaker (Audio board) for frequency feedback
```
